### PR TITLE
support pre-prod configuration with `null` Worklytics Tenant ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,21 +17,21 @@ resource "aws_iam_role" "for_worklytics_tenant" {
   # if `worklytics_tenant_id` is null, then use a placeholder `assume_role_policy` that allows,
   # to support pre-production use case (where infra is created for review, but inaccessible)
   assume_role_policy = var.worklytics_tenant_id == null ? jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = {
-      Sid       = "AllowOwnAccountToAssumeRole"
-      Action    = "sts:AssumeRole",
-      Effect    = "Allow",
+      Sid    = "AllowOwnAccountToAssumeRole"
+      Action = "sts:AssumeRole",
+      Effect = "Allow",
       Principal = {
-        "AWS" =  data.aws_caller_identity.current.account_id
+        "AWS" = data.aws_caller_identity.current.account_id
       }
     }
-  }) : jsonencode({
-    Version   = "2012-10-17"
+    }) : jsonencode({
+    Version = "2012-10-17"
     Statement = {
-      Sid        = "AllowWorklyticsTenantToAssumeRole"
-      Action    = "sts:AssumeRoleWithWebIdentity"
-      Effect    = "Allow"
+      Sid    = "AllowWorklyticsTenantToAssumeRole"
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Effect = "Allow"
       Principal = {
         Federated = "accounts.google.com"
       }

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role" "for_worklytics_tenant" {
   name = "${var.resource_name_prefix}Tenant"
 
   assume_role_policy = jsonencode({
-    Version = "2012-10-17"
+    Version   = "2012-10-17"
     Statement = local.role_assumption_statements
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,6 @@ variable "worklytics_tenant_id" {
 
   validation {
     condition     = var.worklytics_tenant_id == null || can(regex("^\\d{21}$", var.worklytics_tenant_id))
-    error_message = "`worklytics_tenant_id` must be a 21-digit numeric value."
+    error_message = "`worklytics_tenant_id` must be a 21-digit numeric value. (or `null`, for pre-production use case where you don't want external entity to be allowed to assume the role)."
   }
 }


### PR DESCRIPTION
### Features
 - allow pre-prod configuration with `null` value for Worklytics tenant ID

### Change implications

- dependencies added/changed? **no**
