### PR TITLE
Fix release titles/notes and close leftover Trivy S3 alerts

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+# Categories for GitHub's "Generate release notes" button in the UI.
+# The tag workflow uses scripts/generate-release-notes.sh instead, which also
+# drops the "New Contributors" section.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions
+      - github-actions[bot]
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+        - Semver-Major
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Tests & CI
+      labels:
+        - test
+        - ci
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,20 +5,23 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+' # Trigger the workflow on tag push events matching the semantic versioning pattern
 
+permissions:
+  contents: write
+
 jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Git
-        run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Create Release
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref }} -t ${{ github.ref }} --generate-notes
+          TAG="${GITHUB_REF_NAME}"
+          ./scripts/generate-release-notes.sh "${TAG}" > /tmp/release-notes.md
+          gh release create "${TAG}" --title "${TAG}" --notes-file /tmp/release-notes.md

--- a/.github/workflows/terraform_security.yaml
+++ b/.github/workflows/terraform_security.yaml
@@ -30,8 +30,14 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH,MEDIUM
+          # Otherwise SARIF includes LOW findings (e.g. AVD-AWS-0089) even when
+          # `severity` is MEDIUM+; those then linger in the GitHub Security tab.
+          limit-severities-for-sarif: 'true'
           exit-code: '0'          # don't fail the step; let the upload + summary decide
-          trivyignores: .trivyignore   # optional: add this file to the repo to suppress false positives
+          trivyignores: .trivyignore
+          # examples/basic-remote pulls Worklytics/worklytics-export/aws from the
+          # registry; scanning that copy duplicates root-module findings.
+          skip-dirs: examples
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
@@ -48,3 +54,5 @@ jobs:
           format: table
           severity: CRITICAL,HIGH
           exit-code: '1'          # fail the job on CRITICAL or HIGH findings
+          trivyignores: .trivyignore
+          skip-dirs: examples

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,8 @@
-# Encryption is intentionally left to consumers so they can compose with their
-# own aws_s3_bucket_server_side_encryption_configuration / KMS key setup.
-# See README "Customize" guidance and the KMS TODO in main.tf.
+# Encryption, versioning, and access logging are opt-in so callers can compose
+# with their own aws_s3_bucket_* resources / KMS keys. Trivy evaluates `count`
+# from variable defaults (all off), so it still flags the bucket unless ignored.
+# See README "Customize" / "Enable Bucket Versioning" / "Enable Access Logging".
 AVD-AWS-0088
 AVD-AWS-0132
+AVD-AWS-0089
+AVD-AWS-0090

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Next release should be `1.0.0`.** Raising the AWS provider floor from `>= 3.0` to
-> `>= 5.0` is a breaking change for callers still on provider v3/v4.
+### Fixed
+- GitHub code scanning still reported S3 versioning (AVD-AWS-0090) and access logging
+  (AVD-AWS-0089) after v1.0.0. Those resources are opt-in and Trivy evaluates `count` from
+  defaults (`false` / `null`), so the bucket looks unconfigured. Ignore them the same way
+  encryption is ignored, and skip scanning `examples/` so the registry copy of the module
+  is not reported as a second finding.
+
+## [1.0.0] - 2026-08-17
+
+### Breaking Changes
+- Minimum required AWS provider version raised from `>= 3.0` to `>= 5.0`, required by the
+  standalone `aws_s3_bucket_versioning` and `aws_s3_bucket_logging` resources. Callers still
+  on provider v3/v4 will need to upgrade.
 
 ### Added
 - Optional `enable_aws_s3_bucket_versioning` flag (default `false`) to enable versioning on
@@ -17,9 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server access logging when a destination bucket is provided.
 
 ### Changed
-- Minimum required AWS provider version raised from `>= 3.0` to `>= 5.0`, required by the
-  standalone `aws_s3_bucket_versioning` and `aws_s3_bucket_logging` resources. Integration CI
-  now matrices AWS provider majors `~> 5.0` and `~> 6.0` (dropped `~> 3.0`).
+- Integration CI now matrices AWS provider majors `~> 5.0` and `~> 6.0` (dropped `~> 3.0`).
 
 ## [0.5.0] - 2026-05-05
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ from Terraform registry:
 ```hcl
 module "worklytics-export" {
   source  = "Worklytics/worklytics-export/aws"
-  version = "~> 0.5.0"
+  version = "~> 1.0.0"
 
   # numeric ID of your Worklytics Tenant SA
   worklytics_tenant_id = "123123123123"
@@ -26,7 +26,7 @@ module "worklytics-export" {
 via GitHub:
 ```hcl
 module "worklytics-export" {
-  source  = "git::https://github.com/worklytics/terraform-aws-worklytics-export/?ref=v0.5.0"
+  source  = "git::https://github.com/worklytics/terraform-aws-worklytics-export/?ref=v1.0.0"
 
   # numeric ID of your Worklytics Tenant SA
   worklytics_tenant_id = "123123123123"

--- a/examples/basic-remote/main.tf
+++ b/examples/basic-remote/main.tf
@@ -8,7 +8,7 @@ terraform {
 
 module "worklytics_export" {
   source  = "Worklytics/worklytics-export/aws"
-  version = "~> 0.5.0"
+  version = "~> 1.0.0"
 
   resource_name_prefix = var.resource_name_prefix
   worklytics_tenant_id = var.worklytics_tenant_id

--- a/release
+++ b/release
@@ -1,38 +1,130 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# REQUIRES: git
+# DESCRIPTION: Cut a vMAJOR.MINOR.PATCH tag from main. Promotes CHANGELOG.md
+# [Unreleased] into the version section, then pushes the tag so the GitHub
+# Actions workflow can create the GitHub Release.
 
-GREEN='\e[0;32m'
-BLUE='\e[0;34m'
-NC='\e[0m' # No Color
+set -euo pipefail
 
-RELEASE=$1
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
 
-printf "Creating release ${GREEN}$RELEASE${NC}; this should be a semantic version number, e.g. 'v{MAJOR}.{MINOR}.{PATCH}'\n"
+for cmd in git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo -e "${RED}ERROR: ${cmd} is required but not installed.${RESET}"
+    exit 1
+  fi
+done
 
-
-# ensure repo is clean
-if [ -z "$(git status --porcelain)" ]; then
-  printf "${GREEN}Git repository is clean. No uncommitted changes detected.${NC}\n"
-else
-  printf "Uncommitted changes. Discard with ${BLUE}git reset --hard${NC}?\n"
-  read -p "Continue? [y/N] " -n 1 -r
-  DISCARD=${DISCARD:-N}
-
-    echo    # Move to a new line
-    case "$DISCARD" in
-      [nN])
-         git reset --hard
-        ;;
-      *)
-        printf "Chose not to reset; sort this out yourself.\n"
-        exit 1
-        ;;
-    esac
+RELEASE="${1:-}"
+if [[ ! "${RELEASE}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo -e "${RED}ERROR: pass a semantic version tag, e.g. ${BLUE}v1.2.3${RESET}"
+  echo "Usage: ./release v{MAJOR}.{MINOR}.{PATCH}"
+  exit 1
 fi
 
+VERSION="${RELEASE#v}"
+ROOT="$(git rev-parse --show-toplevel)"
+CHANGELOG="${ROOT}/CHANGELOG.md"
+
+echo -e "Creating release ${GREEN}${RELEASE}${RESET}"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo -e "${RED}Uncommitted changes in the working tree.${RESET}"
+  echo -e "Discard them with ${BLUE}git reset --hard${RESET}?"
+  read -r -p "Continue? [y/N] " reply
+  case "${reply}" in
+    [yY])
+      git reset --hard
+      ;;
+    *)
+      echo "Chose not to reset; sort this out yourself."
+      exit 1
+      ;;
+  esac
+fi
 
 git checkout main
 git pull origin main
-git tag $RELEASE
-git push origin $RELEASE
+git fetch origin --tags
 
-printf "Pushing tag ${GREEN}$RELEASE${NC} to origin; GitHub actions workflow should generate release; if not, do it through UX\n"
+if git show-ref --verify --quiet "refs/tags/${RELEASE}"; then
+  echo -e "${RED}ERROR: tag ${BLUE}${RELEASE}${RED} already exists.${RESET}"
+  exit 1
+fi
+
+promote_changelog() {
+  if [[ ! -f "${CHANGELOG}" ]]; then
+    return 0
+  fi
+  if grep -qE "^## \[${VERSION}\]" "${CHANGELOG}"; then
+    echo -e "CHANGELOG already has ${BLUE}[${VERSION}]${RESET}; leaving it as-is."
+    return 0
+  fi
+
+  local today tmp
+  today="$(date +%Y-%m-%d)"
+  tmp="$(mktemp)"
+  awk -v ver="${VERSION}" -v date="${today}" '
+    /^## \[Unreleased\]/ {
+      print "## [Unreleased]"
+      print ""
+      print "## [" ver "] - " date
+      print ""
+      in_unreleased = 1
+      skip_blanks = 1
+      next
+    }
+    in_unreleased && /^## \[/ { in_unreleased = 0 }
+    in_unreleased && /^>/ && /Next release should be/ { skip_quote = 1; next }
+    skip_quote && /^>/ { next }
+    skip_quote { skip_quote = 0 }
+    in_unreleased && skip_blanks && $0 ~ /^[[:space:]]*$/ { next }
+    {
+      skip_blanks = 0
+      print
+    }
+  ' "${CHANGELOG}" > "${tmp}"
+  mv "${tmp}" "${CHANGELOG}"
+  echo -e "Promoted CHANGELOG ${BLUE}[Unreleased]${RESET} → ${GREEN}[${VERSION}] - ${today}${RESET}"
+}
+
+promote_changelog
+
+NOTES_SCRIPT="${ROOT}/scripts/generate-release-notes.sh"
+if [[ -f "${NOTES_SCRIPT}" ]]; then
+  echo
+  echo -e "${GREEN}Release notes preview:${RESET}"
+  echo "-----"
+  bash "${NOTES_SCRIPT}" "${RELEASE}" || true
+  echo "-----"
+  echo
+fi
+
+read -r -p "Tag ${RELEASE} and push to origin? [y/N] " reply
+case "${reply}" in
+  [yY]) ;;
+  *)
+    echo "Aborted; tag was not created."
+    if [[ -n "$(git status --porcelain -- "${CHANGELOG}" 2>/dev/null || true)" ]]; then
+      echo -e "CHANGELOG.md was updated in the working tree; discard with ${BLUE}git checkout -- CHANGELOG.md${RESET} if you want."
+    fi
+    exit 1
+    ;;
+esac
+
+if [[ -n "$(git status --porcelain -- "${CHANGELOG}")" ]]; then
+  git add "${CHANGELOG}"
+  git commit -m "Release ${RELEASE}"
+fi
+
+git tag "${RELEASE}"
+if [[ -n "$(git log origin/main..HEAD --oneline 2>/dev/null || true)" ]]; then
+  git push origin main
+fi
+git push origin "${RELEASE}"
+
+echo -e "Pushed tag ${GREEN}${RELEASE}${RESET}; GitHub Actions should create the release."
+echo -e "If it does not, create it with ${BLUE}gh release create ${RELEASE} --title ${RELEASE} --notes-file <(scripts/generate-release-notes.sh ${RELEASE})${RESET}"

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# REQUIRES: git
+# DESCRIPTION: Print GitHub release notes for a tag to stdout.
+#
+# Prefers the matching CHANGELOG.md section, remaps Added/Fixed to Features/Fixes,
+# and hoists breaking changes to the top. Falls back to categorizing merged PRs.
+# Omits GitHub's "New Contributors" / author shout-outs.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <tag>" >&2
+  echo "  tag  e.g. v1.2.3 (GITHUB_REF_NAME is used if omitted in Actions)" >&2
+  exit 1
+}
+
+TAG="${1:-${GITHUB_REF_NAME:-}}"
+if [[ -z "$TAG" ]]; then
+  usage
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+CHANGELOG="${ROOT}/CHANGELOG.md"
+VERSION="${TAG#v}"
+
+github_repo() {
+  if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+    echo "${GITHUB_REPOSITORY}"
+    return
+  fi
+  local url
+  url="$(git remote get-url origin 2>/dev/null || true)"
+  url="${url%.git}"
+  url="${url#git@github.com:}"
+  url="${url#https://github.com/}"
+  url="${url#ssh://git@github.com/}"
+  echo "${url}"
+}
+
+previous_tag() {
+  # Semver order, not git ancestry — tags in this repo are not always ancestors
+  # of main (e.g. v0.5.0 was cut from a merge commit off to the side).
+  git tag -l 'v[0-9]*' --sort=v:refname | awk -v cur="${TAG}" '
+    $0 == cur { print prev; exit }
+    { prev = $0 }
+    END { if ($0 != cur && $0 != "") print $0 }
+  '
+}
+
+# Extract a ## [heading] section from CHANGELOG.md (body only, no ## heading).
+extract_changelog_section() {
+  local heading="$1"
+  awk -v heading="${heading}" '
+    BEGIN { p = 0 }
+    /^## \[/ {
+      if (p) exit
+      if ($0 ~ "^## \\[" heading "\\]") {
+        p = 1
+        next
+      }
+      next
+    }
+    p { print }
+  ' "${CHANGELOG}"
+}
+
+# Drop Keep-a-Changelog process notes like "Next release should be ...".
+strip_process_notes() {
+  awk '
+    /^>/ && /Next release should be/ { skip = 1; next }
+    skip && /^>/ { next }
+    skip && /^[[:space:]]*$/ { skip = 0; next }
+    { skip = 0; print }
+  '
+}
+
+# Remap Keep-a-Changelog headings, hoist breaking-change bullets, emit in a
+# stable order. Blank / heading-only input prints nothing.
+format_changelog_body() {
+  awk '
+    function remap(h) {
+      if (h == "### Added") return "### Features"
+      if (h == "### Fixed") return "### Fixes"
+      if (h == "### Changed") return "### Changes"
+      if (h ~ /^### [Bb]reaking/) return "### Breaking changes"
+      return h
+    }
+    function flush_bullet(    is_breaking) {
+      if (bullet == "") return
+      is_breaking = (tolower(bullet) ~ /breaking change/)
+      if (is_breaking && cur != "### Breaking changes") {
+        breaking = breaking bullet
+      } else {
+        buf = buf bullet
+      }
+      bullet = ""
+    }
+    function store_section() {
+      flush_bullet()
+      if (cur != "") {
+        sub(/\n+$/, "", buf)
+        sections[cur] = buf "\n"
+      }
+      buf = ""
+    }
+    function nonempty(s) {
+      return (s ~ /[^[:space:]]/)
+    }
+    function dump(title) {
+      body = (title == "### Breaking changes") ? (breaking sections[title]) : sections[title]
+      if (!nonempty(body)) return
+      if (emitted) print ""
+      print title
+      printf "%s", body
+      if (body !~ /\n$/) print ""
+      emitted = 1
+      seen[title] = 1
+    }
+    /^### / {
+      store_section()
+      cur = remap($0)
+      buf = ""
+      bullet = ""
+      next
+    }
+    /^- / {
+      flush_bullet()
+      bullet = $0 "\n"
+      next
+    }
+    /^[[:space:]]*$/ {
+      next
+    }
+    {
+      if (bullet != "") {
+        bullet = bullet $0 "\n"
+      } else {
+        buf = buf $0 "\n"
+      }
+    }
+    END {
+      store_section()
+      dump("### Breaking changes")
+      dump("### Features")
+      dump("### Fixes")
+      dump("### Changes")
+      dump("### Deprecated")
+      dump("### Removed")
+      dump("### Security")
+      for (h in sections) {
+        if (!seen[h]) dump(h)
+      }
+    }
+  '
+}
+
+changelog_has_content() {
+  local text="$1"
+  # Ignore headings and blank lines when deciding whether the section is empty.
+  echo "${text}" | grep -vE '^[[:space:]]*$|^#' | grep -q '[^[:space:]]'
+}
+
+REPO="$(github_repo)"
+PREV="$(previous_tag)"
+
+changelog_body=""
+if [[ -f "${CHANGELOG}" ]]; then
+  raw="$(extract_changelog_section "${VERSION}")"
+  if ! changelog_has_content "${raw}"; then
+    raw="$(extract_changelog_section "v${VERSION}")"
+  fi
+  if ! changelog_has_content "${raw}"; then
+    # Tag may have been cut before Unreleased was promoted.
+    raw="$(extract_changelog_section "Unreleased")"
+  fi
+  if changelog_has_content "${raw}"; then
+    changelog_body="$(printf '%s\n' "${raw}" | strip_process_notes | format_changelog_body)"
+    if ! changelog_has_content "${changelog_body}"; then
+      changelog_body=""
+    fi
+  fi
+fi
+
+categorize_pr() {
+  local title="$1"
+  local labels="$2"
+  local t
+  t="$(printf '%s' "${title}" | tr '[:upper:]' '[:lower:]')"
+  labels="$(printf '%s' "${labels}" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "${labels}" == *breaking* || "${t}" == *breaking* ]]; then
+    echo breaking
+    return
+  fi
+  if [[ "${labels}" == *bug* ]]; then
+    echo fixes
+    return
+  fi
+  if [[ "${labels}" == *enhancement* ]]; then
+    echo features
+    return
+  fi
+  if [[ "${labels}" == *documentation* ]]; then
+    echo docs
+    return
+  fi
+  if [[ "${t}" =~ (^|[^[:alpha:]])(fix|fixed|fixes|bugfix|hotfix)([^[:alpha:]]|$) ]]; then
+    echo fixes
+    return
+  fi
+  if [[ "${t}" =~ (^|[^[:alpha:]])(feat|feature)([^[:alpha:]]|$) ]]; then
+    echo features
+    return
+  fi
+  if [[ "${t}" =~ (^|[^[:alpha:]])(added|adds|adding|add)([^[:alpha:]]|$) ]]; then
+    echo features
+    return
+  fi
+  if [[ "${t}" =~ (^|[^[:alpha:]])(support)([^[:alpha:]]|$) ]]; then
+    echo features
+    return
+  fi
+  if [[ "${t}" =~ (^|[^[:alpha:]])(docs?|documentation|readme)([^[:alpha:]]|$) ]]; then
+    echo docs
+    return
+  fi
+  if [[ "${t}" =~ (^|[^[:alpha:]])(ci|tests?|testing|workflow|lint)([^[:alpha:]]|$) ]]; then
+    echo ci
+    return
+  fi
+  echo other
+}
+
+# Populate categorized PR arrays from git history (no authors / contributors).
+pr_breaking=()
+pr_features=()
+pr_fixes=()
+pr_docs=()
+pr_ci=()
+pr_other=()
+full_changelog=""
+
+load_prs_from_git() {
+  local range_end="${TAG}"
+  if ! git rev-parse "${TAG}^{commit}" >/dev/null 2>&1; then
+    range_end="HEAD"
+  fi
+  local log_range
+  if [[ -n "${PREV}" ]]; then
+    log_range="${PREV}..${range_end}"
+  else
+    log_range="${range_end}"
+  fi
+
+  local subject num title url cat item seen_prs=" "
+  while IFS= read -r subject; do
+    num=""
+    title=""
+    if [[ "${subject}" =~ Merge\ pull\ request\ #([0-9]+) ]]; then
+      num="${BASH_REMATCH[1]}"
+      title="${subject}"
+    elif [[ "${subject}" =~ \(#([0-9]+)\) ]]; then
+      num="${BASH_REMATCH[1]}"
+      title="$(printf '%s' "${subject}" | sed -E "s/[[:space:]]*\\(#${num}\\)[[:space:]]*$//")"
+    else
+      continue
+    fi
+    if [[ "${seen_prs}" == *" ${num} "* ]]; then
+      continue
+    fi
+    seen_prs="${seen_prs}${num} "
+    url="https://github.com/${REPO}/pull/${num}"
+    cat="$(categorize_pr "${title}" "")"
+    item="- [${title}](${url})"
+    case "${cat}" in
+      breaking) pr_breaking+=("${item}") ;;
+      features) pr_features+=("${item}") ;;
+      fixes) pr_fixes+=("${item}") ;;
+      docs) pr_docs+=("${item}") ;;
+      ci) pr_ci+=("${item}") ;;
+      *) pr_other+=("${item}") ;;
+    esac
+  done < <(git log "${log_range}" --pretty='%s')
+}
+
+emit_pr_section() {
+  local heading="$1"
+  shift
+  if [[ "$#" -eq 0 ]]; then
+    return
+  fi
+  echo "### ${heading}"
+  echo
+  local item
+  for item in "$@"; do
+    echo "${item}"
+  done
+  echo
+}
+
+if [[ -z "${changelog_body}" ]]; then
+  load_prs_from_git
+fi
+
+if [[ -z "${full_changelog}" && -n "${REPO}" && -n "${PREV}" ]]; then
+  full_changelog="**Full Changelog**: https://github.com/${REPO}/compare/${PREV}...${TAG}"
+elif [[ -z "${full_changelog}" && -n "${REPO}" ]]; then
+  full_changelog="**Full Changelog**: https://github.com/${REPO}/releases/tag/${TAG}"
+fi
+
+{
+  if [[ -n "${changelog_body}" ]]; then
+    printf '%s\n' "${changelog_body}"
+    echo
+  else
+    emit_pr_section "Breaking changes" "${pr_breaking[@]+"${pr_breaking[@]}"}"
+    emit_pr_section "Features" "${pr_features[@]+"${pr_features[@]}"}"
+    emit_pr_section "Fixes" "${pr_fixes[@]+"${pr_fixes[@]}"}"
+    emit_pr_section "Documentation" "${pr_docs[@]+"${pr_docs[@]}"}"
+    emit_pr_section "Tests & CI" "${pr_ci[@]+"${pr_ci[@]}"}"
+    emit_pr_section "Other changes" "${pr_other[@]+"${pr_other[@]}"}"
+  fi
+  if [[ -n "${full_changelog}" ]]; then
+    echo "${full_changelog}"
+  fi
+}


### PR DESCRIPTION
## Summary
- Release workflow was using `github.ref` (`refs/tags/v1.0.0`) as the tag and title; it now uses the tag name and CHANGELOG-based notes (features / fixes / breaking changes, no Contributors section).
- v1.0.0 added optional versioning and logging, but Trivy still flags the bucket because those resources are `count = 0` at defaults. Ignore AVD-AWS-0090 / AVD-AWS-0089 the same way encryption is ignored, and skip scanning `examples/` so the registry copy is not reported twice.

### Fixes
Code scanning alerts that should close after this lands on `main` and Trivy re-uploads SARIF:

- [S3 Data should be versioned (AVD-AWS-0090) — `main.tf`](https://github.com/Worklytics/terraform-aws-worklytics-export/security/code-scanning/2)
- [S3 Bucket Logging (AVD-AWS-0089) — `main.tf`](https://github.com/Worklytics/terraform-aws-worklytics-export/security/code-scanning/1)
- [S3 Data should be versioned (AVD-AWS-0090) — registry copy](https://github.com/Worklytics/terraform-aws-worklytics-export/security/code-scanning/4)
- [S3 Bucket Logging (AVD-AWS-0089) — registry copy](https://github.com/Worklytics/terraform-aws-worklytics-export/security/code-scanning/3)

### Change implications
- dependencies added/changed? **no**

## Test plan
- [ ] Confirm a dry run of `scripts/generate-release-notes.sh v1.0.0` emits Breaking / Features / Changes and no Contributors
- [ ] After merge, confirm the Trivy workflow SARIF upload closes the four alerts above
- [ ] Spot-check README / `examples/basic-remote` now pin `~> 1.0.0`


Made with [Cursor](https://cursor.com)